### PR TITLE
init_app should set self.app

### DIFF
--- a/flask_thumbnails/__init__.py
+++ b/flask_thumbnails/__init__.py
@@ -32,6 +32,8 @@ class Thumbnail(object):
             self.init_app(app)
 
     def init_app(self, app):
+        if self.app is None:
+            self.app = app
         app.thumbnail_instance = self
 
         if not hasattr(app, 'extensions'):


### PR DESCRIPTION
init_app needs to set self.app (which is used throughout) in the event someone uses the Thumbnail constructor without passing in the app.
