### PR TITLE
[bugfix] image rotation according to EXIF information (closes #19)

### DIFF
--- a/flask_thumbnails/thumbnail.py
+++ b/flask_thumbnails/thumbnail.py
@@ -171,6 +171,8 @@ class Thumbnail:
         except AttributeError:  # pylint: disable=raise-missing-from
             resample = Image.ANTIALIAS
 
+        image = ImageOps.exif_transpose(image)
+
         if crop == "fit":
             image = ImageOps.fit(image, size, resample)
         else:


### PR DESCRIPTION
The issue shown in #19 was fixed by using the PIL.ImageOps function `exif_transpose()`.